### PR TITLE
VAUL-40: Implement authenticated user profile endpoint with @CurrentU…

### DIFF
--- a/backend/prisma/migrations/20250329043456_add_role_enum/migration.sql
+++ b/backend/prisma/migrations/20250329043456_add_role_enum/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - The `role` column on the `User` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+
+*/
+-- CreateEnum
+CREATE TYPE "Role" AS ENUM ('USER', 'ADMIN');
+
+-- AlterTable
+ALTER TABLE "User" DROP COLUMN "role",
+ADD COLUMN     "role" "Role" NOT NULL DEFAULT 'USER';

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -37,11 +37,16 @@ model User {
   name String
   email String @unique
   password String
-  role String
+  role Role @default(USER)
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now())
   deletedAt DateTime?
 
   // Relations
   shop Shop? @relation(fields: [shop_id], references: [id])
+}
+
+enum Role {
+  USER
+  ADMIN
 }

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -5,6 +5,7 @@ import * as bcrypt from 'bcryptjs';
 import { CreateUserDto } from '../users/dtos/create-user.dto';
 import { UsersService } from '../users/users.service';
 import { ConfigService } from '@nestjs/config';
+import { Role } from '@prisma/client';
 
 @Injectable()
 export class AuthService {
@@ -15,7 +16,7 @@ export class AuthService {
     private configService: ConfigService
   ) {}
 
-  private generateTokens(userId: string, email: string, role: string) {
+  private generateTokens(userId: string, email: string, role: Role) {
     const payload = { id: userId, email, roles: [role] };
 
     const accessToken = this.jwtService.sign(payload, {
@@ -67,5 +68,32 @@ export class AuthService {
     if (!isMatch) throw new BadRequestException('Invalid credentials');
 
     return this.generateTokens(user.id, user.email, user.role);
+  }
+
+  async getProfile(userId: string) {
+    return this.prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        id: true,
+        email: true,
+        name: true,
+        role: true,
+        createdAt: true,
+        updatedAt: true,
+        shop: {
+          select: {
+            id: true,
+            name: true,
+            address: true,
+            contactInfo: true,
+            logo: true,
+            hours: true,
+            location: true,
+            policies: true,
+            planId: true,
+          }
+        }
+      },
+    });
   }
 }

--- a/backend/src/auth/dtos/user-profile-response.dto.ts
+++ b/backend/src/auth/dtos/user-profile-response.dto.ts
@@ -1,0 +1,54 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Role } from '@prisma/client';
+
+class ShopProfileDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  name: string;
+
+  @ApiProperty()
+  address: string;
+
+  @ApiProperty()
+  contactInfo: string;
+
+  @ApiProperty({ required: false, nullable: true })
+  logo?: string | null;
+
+  @ApiProperty({ required: false, nullable: true })
+  hours?: string | null;
+
+  @ApiProperty({ required: false, nullable: true })
+  location?: string | null;
+
+  @ApiProperty({ required: false, nullable: true })
+  policies?: string | null;
+
+  @ApiProperty({ required: false, nullable: true })
+  planId?: string | null;
+}
+
+export class UserProfileResponseDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  email: string;
+
+  @ApiProperty()
+  name: string;
+
+  @ApiProperty({ enum: Role })
+  role: Role;
+
+  @ApiProperty()
+  createdAt: Date;
+
+  @ApiProperty()
+  updatedAt: Date;
+
+  @ApiProperty({ type: ShopProfileDto, required: false, nullable: true })
+  shop?: ShopProfileDto | null;
+}

--- a/backend/src/auth/types/express.d.ts
+++ b/backend/src/auth/types/express.d.ts
@@ -1,0 +1,7 @@
+import { JwtPayload } from "./jwt-payload.type";
+
+declare global {
+    namespace Express {
+        interface User extends JwtPayload {}
+    }
+}

--- a/backend/src/auth/types/jwt-payload.type.ts
+++ b/backend/src/auth/types/jwt-payload.type.ts
@@ -1,0 +1,7 @@
+import { Role } from "@prisma/client";
+
+export interface JwtPayload {
+    id: string;
+    email: string;
+    roles: Role[]
+}

--- a/backend/src/common/decorators/current-user.decorator.ts
+++ b/backend/src/common/decorators/current-user.decorator.ts
@@ -1,0 +1,11 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+export const CurrentUser = createParamDecorator<
+  keyof Express.User | undefined,
+  ExecutionContext
+>((field, ctx) => {
+  const request = ctx.switchToHttp().getRequest();
+  const user = request.user;
+
+  return field ? user?.[field] : user;
+});

--- a/backend/src/users/dtos/create-user.dto.ts
+++ b/backend/src/users/dtos/create-user.dto.ts
@@ -1,5 +1,6 @@
-import { IsEmail, IsNotEmpty, MinLength } from 'class-validator';
+import { IsEmail, IsNotEmpty, MinLength, IsEnum } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
+import { Role } from '@prisma/client'; 
 
 export class CreateUserDto {
     @ApiProperty({ example: 'user@example.com' })
@@ -13,4 +14,8 @@ export class CreateUserDto {
     @ApiProperty({ example: 'StrongPassword123' })
     @MinLength(6)
     password: string;
+
+    @ApiProperty({ enum: Role, default: Role.USER })
+    @IsEnum(Role)
+    role?: Role = Role.USER
 }

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -1,7 +1,8 @@
 import { Injectable, ConflictException } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
-import { CreateUserDto } from './dtos/create-user.dto';
+import { CreateUserDto} from './dtos/create-user.dto';
 import * as bcrypt from 'bcryptjs';
+import { Role } from '@prisma/client';
 
 @Injectable()
 export class UsersService {
@@ -22,7 +23,7 @@ export class UsersService {
         email,
         name,
         password: hashedPassword,
-        role: 'user',
+        role: createUserDto.role ?? Role.USER
       },
     });
 


### PR DESCRIPTION
- Added `/auth/profile` endoint to fetch logged-in user's full profile
- Uses new `@CurrentUser()` decorator
- Returns typed `UserProfileResponseDto`
- Includes associated shop data (if present)
