### PR TITLE
VAUL-60: Add update profile endpoint with optional password update

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -3,6 +3,7 @@ import {
   Post,
   Body,
   Get,
+  Patch,
   Req,
   Res,
   UseGuards,
@@ -12,6 +13,7 @@ import { AuthService } from './auth.service';
 import { CreateUserDto } from '../users/dtos/create-user.dto';
 import { UserResponseDto } from '../users/dtos/user-response.dto';
 import { UserProfileResponseDto } from './dtos/user-profile-response.dto';
+import { UpdateUserDto } from 'src/users/dtos/update-user.dto';
 import { LoginDto } from './dtos/login.dto';
 import { AuthGuard } from '@nestjs/passport';
 import { Request, Response } from 'express';
@@ -91,5 +93,25 @@ export class AuthController {
     }
   
     return dbUser;
+  }
+
+  @Patch('profile')
+  @UseGuards(AuthGuard('jwt'))
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: 'Update authenticated user profile' })
+  @ApiOkResponse({ type: UserProfileResponseDto })
+  @ApiResponse({ status: 400, description: 'Validation error' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  async updateProfile(
+    @CurrentUser() user: any,
+    @Body() dto: UpdateUserDto,
+  ): Promise<UserProfileResponseDto> {
+    const updatedUser = await this.authService.updateProfile(user.id, dto);
+  
+    if (!updatedUser) {
+      throw new UnauthorizedException('User not found');
+    }
+  
+    return updatedUser;
   }
 }

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -6,6 +6,7 @@ import { CreateUserDto } from '../users/dtos/create-user.dto';
 import { UsersService } from '../users/users.service';
 import { ConfigService } from '@nestjs/config';
 import { Role } from '@prisma/client';
+import { UpdateUserDto } from 'src/users/dtos/update-user.dto';
 
 @Injectable()
 export class AuthService {
@@ -95,5 +96,45 @@ export class AuthService {
         }
       },
     });
+  }
+
+  async updateProfile(userId: string, dto: UpdateUserDto) {
+    const dataToUpdate: any = { ...dto };
+
+    // if password is provided, hash it
+    if (dto.password) {
+      dataToUpdate.password = await bcrypt.hash(dto.password, 10);
+    }
+
+    const updatedUser = await this.prisma.user.update({
+      where: { id: userId },
+      data: {
+        ...dataToUpdate,
+        updatedAt: new Date(),
+      },
+      select: {
+        id: true,
+        email: true,
+        name: true,
+        role: true,
+        createdAt: true,
+        updatedAt: true,
+        shop: {
+          select: {
+            id: true,
+            name: true,
+            address: true,
+            contactInfo: true,
+            logo: true,
+            hours: true,
+            location: true,
+            policies: true,
+            planId: true,
+          },
+        },
+      },
+    });
+
+    return updatedUser;
   }
 }

--- a/backend/src/users/dtos/update-user.dto.ts
+++ b/backend/src/users/dtos/update-user.dto.ts
@@ -1,0 +1,19 @@
+import { IsOptional, IsEmail, IsString, MinLength } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class UpdateUserDto {
+  @ApiPropertyOptional({ example: 'Jane Doe' })
+  @IsOptional()
+  @IsString()
+  name?: string;
+
+  @ApiPropertyOptional({ example: 'user@example.com' })
+  @IsOptional()
+  @IsEmail()
+  email?: string;
+
+  @ApiPropertyOptional({ example: 'NewStrongPassword123' })
+  @IsOptional()
+  @MinLength(6)
+  password?: string;
+}


### PR DESCRIPTION
This PR introduces an authenticated endpoint allowing users to update their profile, including:
- name, email, and password updates
- validated via `UpdateUsersDto`
- only available to logged-in users 
- Swagger integration for testing and documentation

Additional Notes:
- Shop info is returned in profile response, but not editable in this ticket
- No breaking changes introduced
- sets up clean separation for future shop-editing tickets