### PR TITLE
VAUL-61 Allow admins to update their own shop

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -4,9 +4,10 @@ import { AppService } from './app.service';
 import { AuthModule } from './auth/auth.module';
 import { UsersModule } from './users/users.module';
 import { PrismaModule } from './prisma/prisma.module';
+import { ShopModule } from './shop/shop.module';
 
 @Module({
-  imports: [AuthModule, UsersModule, PrismaModule],
+  imports: [AuthModule, UsersModule, PrismaModule, ShopModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/backend/src/prisma/prisma.module.ts
+++ b/backend/src/prisma/prisma.module.ts
@@ -1,6 +1,7 @@
-import { Module } from '@nestjs/common';
+import { Global, Module } from '@nestjs/common';
 import { PrismaService } from './prisma.service';
 
+@Global()
 @Module({
   providers: [PrismaService],
   exports: [PrismaService],

--- a/backend/src/shop/dto/update-shop.dto.ts
+++ b/backend/src/shop/dto/update-shop.dto.ts
@@ -1,0 +1,44 @@
+import { IsOptional, IsString } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class UpdateShopDto {
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  name?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  address?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  contactInfo?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  logo?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  hours?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  location?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  policies?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  planId?: string;
+}

--- a/backend/src/shop/shop.controller.ts
+++ b/backend/src/shop/shop.controller.ts
@@ -1,0 +1,39 @@
+import {
+    Controller,
+    Patch,
+    Body,
+    Param,
+    UseGuards,
+  } from '@nestjs/common';
+  import { ShopService } from './shop.service';
+  import { UpdateShopDto } from './dto/update-shop.dto';
+  import { AuthGuard } from '@nestjs/passport';
+  import { CurrentUser } from 'src/common/decorators/current-user.decorator';
+  import {
+    ApiBearerAuth,
+    ApiOkResponse,
+    ApiOperation,
+    ApiResponse,
+    ApiTags,
+  } from '@nestjs/swagger';
+  
+  @ApiTags('shop')
+  @Controller('shop')
+  export class ShopController {
+    constructor(private readonly shopService: ShopService) {}
+  
+    @Patch(':id')
+    @UseGuards(AuthGuard('jwt'))
+    @ApiBearerAuth('access-token')
+    @ApiOperation({ summary: 'Update a shop (admin only)' })
+    @ApiOkResponse({ description: 'Updated shop data' })
+    @ApiResponse({ status: 403, description: 'Forbidden' })
+    async updateShop(
+      @Param('id') shopId: string,
+      @CurrentUser() user: any,
+      @Body() dto: UpdateShopDto,
+    ) {
+      return this.shopService.updateShop(user.id, shopId, dto);
+    }
+  }
+  

--- a/backend/src/shop/shop.module.ts
+++ b/backend/src/shop/shop.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ShopService } from './shop.service';
+import { ShopController } from './shop.controller';
+
+@Module({
+  providers: [ShopService],
+  controllers: [ShopController]
+})
+export class ShopModule {}

--- a/backend/src/shop/shop.service.ts
+++ b/backend/src/shop/shop.service.ts
@@ -1,0 +1,42 @@
+import {
+    ForbiddenException,
+    Injectable,
+    NotFoundException,
+  } from '@nestjs/common';
+  import { UpdateShopDto } from './dto/update-shop.dto';
+  import { PrismaService } from 'src/prisma/prisma.service';
+  
+  @Injectable()
+  export class ShopService {
+    constructor(private prisma: PrismaService) {}
+  
+    async updateShop(userId: string, shopId: string, dto: UpdateShopDto) {
+      const user = await this.prisma.user.findUnique({
+        where: { id: userId },
+        select: { role: true, shop_id: true },
+      });
+  
+      if (!user || user.role !== 'ADMIN') {
+        throw new ForbiddenException('Only admins can update shops.');
+      }
+  
+      const shop = await this.prisma.shop.findUnique({ where: { id: shopId } });
+  
+      if (!shop) {
+        throw new NotFoundException('Shop not found.');
+      }
+  
+      if (user.shop_id !== shopId) {
+        throw new ForbiddenException('You do not have access to edit this shop.');
+      }
+  
+      return this.prisma.shop.update({
+        where: { id: shopId },
+        data: {
+          ...dto,
+          updatedAt: new Date(),
+        },
+      });
+    }
+  }
+  


### PR DESCRIPTION
- Added `PATCH /shop/:id` endpoint for updating shop details. 
- Restricted access to ADMIN users only
- Ensured admins can only update shops they are associated with 
- Added DTO validation for shop update fields
- Secured route with JWT