### PR TITLE
VAUL-62: Allow admins to create and update shops with proper role-bas…

### DIFF
--- a/backend/src/shop/dto/create-shop.dto.ts
+++ b/backend/src/shop/dto/create-shop.dto.ts
@@ -1,0 +1,41 @@
+import { IsOptional, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreateShopDto {
+  @ApiProperty()
+  @IsString()
+  name: string;
+
+  @ApiProperty()
+  @IsString()
+  address: string;
+
+  @ApiProperty()
+  @IsString()
+  contactInfo: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  logo?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  hours?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  location?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  policies?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  planId?: string;
+}

--- a/backend/src/shop/shop.controller.ts
+++ b/backend/src/shop/shop.controller.ts
@@ -4,6 +4,8 @@ import {
     Body,
     Param,
     UseGuards,
+    Post,
+    ForbiddenException,
   } from '@nestjs/common';
   import { ShopService } from './shop.service';
   import { UpdateShopDto } from './dto/update-shop.dto';
@@ -16,11 +18,29 @@ import {
     ApiResponse,
     ApiTags,
   } from '@nestjs/swagger';
+import { CreateShopDto } from './dto/create-shop.dto';
   
   @ApiTags('shop')
   @Controller('shop')
   export class ShopController {
     constructor(private readonly shopService: ShopService) {}
+
+    @Post()
+    @UseGuards(AuthGuard('jwt'))
+    @ApiBearerAuth('access-token')
+    @ApiOperation({ summary: 'Create a shop (admin only)' })
+    @ApiResponse({ status: 201, description: 'Shop created successfully' })
+    @ApiResponse({ status: 403, description: 'Forbidden' })
+    async createShop(
+      @CurrentUser() user: any,
+      @Body() dto: CreateShopDto,
+    ) {
+      if (user.role !== 'ADMIN') {
+        throw new ForbiddenException('Only admins can create shops.');
+      }
+  
+      return this.shopService.createShop(user.id, dto);
+    }
   
     @Patch(':id')
     @UseGuards(AuthGuard('jwt'))

--- a/backend/src/shop/shop.service.ts
+++ b/backend/src/shop/shop.service.ts
@@ -4,11 +4,42 @@ import {
     NotFoundException,
   } from '@nestjs/common';
   import { UpdateShopDto } from './dto/update-shop.dto';
+  import { CreateShopDto } from './dto/create-shop.dto';
   import { PrismaService } from 'src/prisma/prisma.service';
   
   @Injectable()
   export class ShopService {
     constructor(private prisma: PrismaService) {}
+  
+    async createShop(userId: string, dto: CreateShopDto) {
+      const user = await this.prisma.user.findUnique({
+        where: { id: userId },
+        select: { role: true },
+      });
+  
+      if (!user || user.role !== 'ADMIN') {
+        throw new ForbiddenException('Only admins can create shops.');
+      }
+  
+      const shop = await this.prisma.shop.create({
+        data: {
+          ...dto,
+          users: {
+            connect: { id: userId }, // Link user to shop
+          },
+        },
+      });
+  
+      // Set user's shop_id (1-to-1 reference)
+      await this.prisma.user.update({
+        where: { id: userId },
+        data: {
+          shop_id: shop.id,
+        },
+      });
+  
+      return shop;
+    }
   
     async updateShop(userId: string, shopId: string, dto: UpdateShopDto) {
       const user = await this.prisma.user.findUnique({
@@ -20,12 +51,15 @@ import {
         throw new ForbiddenException('Only admins can update shops.');
       }
   
-      const shop = await this.prisma.shop.findUnique({ where: { id: shopId } });
+      const shop = await this.prisma.shop.findUnique({
+        where: { id: shopId },
+      });
   
       if (!shop) {
         throw new NotFoundException('Shop not found.');
       }
   
+      // Optional security: restrict editing to assigned shop
       if (user.shop_id !== shopId) {
         throw new ForbiddenException('You do not have access to edit this shop.');
       }


### PR DESCRIPTION
✅ What was done:
- Implemented POST /shop to allow admins to create a new shop.
- Implemented PATCH /shop/:id to allow admins to update their own shop.
- Restricted both routes to users with role: ADMIN using:
   - @UseGuards(AuthGuard('jwt'))
   - Custom @CurrentUser() role validation.
- Connected created shop to the admin user (shop_id logic handled).
- Added proper DTOs (CreateShopDto, UpdateShopDto) and API docs via Swagger decorators.

🔐 Access Control:
- Users must be authenticated.
- Only users with role: ADMIN can create or edit shop records.
- Admins can only edit their own shop (based on shop_id match).

📸 Swagger Ready:
- Routes are fully documented and testable through Swagger UI.

🔍 Tested:
Manually tested in Swagger UI with JWT tokens for:
✅ Create shop
✅ Update shop
✅ Guard protection (403 returned for non-admins)