### PR TITLE
VAUL-63: Admin assigns user to shop with scoped role support

### DIFF
--- a/backend/prisma/migrations/20250329075936_convert_user_shop_to_many_to_many/migration.sql
+++ b/backend/prisma/migrations/20250329075936_convert_user_shop_to_many_to_many/migration.sql
@@ -1,0 +1,31 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `shop_id` on the `User` table. All the data in the column will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "User" DROP CONSTRAINT "User_shop_id_fkey";
+
+-- AlterTable
+ALTER TABLE "User" DROP COLUMN "shop_id";
+
+-- CreateTable
+CREATE TABLE "ShopUser" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "shopId" TEXT NOT NULL,
+    "role" "Role" NOT NULL DEFAULT 'USER',
+    "assignedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ShopUser_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ShopUser_userId_shopId_key" ON "ShopUser"("userId", "shopId");
+
+-- AddForeignKey
+ALTER TABLE "ShopUser" ADD CONSTRAINT "ShopUser_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ShopUser" ADD CONSTRAINT "ShopUser_shopId_fkey" FOREIGN KEY ("shopId") REFERENCES "Shop"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -13,40 +13,49 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-model Shop {
-  id String @id @default(cuid())
-  name String
-  address String
-  contactInfo String
-  logo String?
-  hours String?
-  location String?
-  policies String?
-  planId String?
-  createdAt DateTime @default(now())
-  updatedAt DateTime @default(now())
-  deletedAt DateTime?
-
-  // Relations
-  users User[]
-}
-
 model User {
-  id String @id @default(uuid())
-  shop_id String?
-  name String
-  email String @unique
-  password String
-  role Role @default(USER)
-  createdAt DateTime @default(now())
-  updatedAt DateTime @default(now())
+  id        String      @id @default(uuid())
+  name      String
+  email     String      @unique
+  password  String
+  role      Role        @default(USER)
+  createdAt DateTime    @default(now())
+  updatedAt DateTime    @default(now())
   deletedAt DateTime?
 
-  // Relations
-  shop Shop? @relation(fields: [shop_id], references: [id])
+  shopUsers ShopUser[]
 }
 
 enum Role {
   USER
   ADMIN
+}
+
+model Shop {
+  id         String      @id @default(uuid())
+  name       String
+  address    String
+  contactInfo String
+  logo       String?
+  hours      String?
+  location   String?
+  policies   String?
+  planId     String?
+  createdAt  DateTime    @default(now())
+  updatedAt  DateTime    @default(now())
+  deletedAt  DateTime?
+
+  shopUsers ShopUser[]
+}
+
+model ShopUser {
+  id        String   @id @default(uuid())
+  user      User     @relation(fields: [userId], references: [id])
+  userId    String
+  shop      Shop     @relation(fields: [shopId], references: [id])
+  shopId    String   @default(uuid())
+  role      Role     @default(USER)
+  assignedAt DateTime @default(now())
+
+  @@unique([userId, shopId])
 }

--- a/backend/src/auth/dtos/user-profile-response.dto.ts
+++ b/backend/src/auth/dtos/user-profile-response.dto.ts
@@ -30,6 +30,17 @@ class ShopProfileDto {
   planId?: string | null;
 }
 
+class ShopAssignmentDto {
+  @ApiProperty({ enum: Role })
+  role: Role;
+
+  @ApiProperty()
+  assignedAt: Date;
+
+  @ApiProperty({ type: ShopProfileDto })
+  shop: ShopProfileDto;
+}
+
 export class UserProfileResponseDto {
   @ApiProperty()
   id: string;
@@ -49,6 +60,6 @@ export class UserProfileResponseDto {
   @ApiProperty()
   updatedAt: Date;
 
-  @ApiProperty({ type: ShopProfileDto, required: false, nullable: true })
-  shop?: ShopProfileDto | null;
+  @ApiProperty({ type: [ShopAssignmentDto], required: false })
+  shopUsers: ShopAssignmentDto[];
 }

--- a/backend/src/shop/dto/assign-user-to-shop.dto.ts
+++ b/backend/src/shop/dto/assign-user-to-shop.dto.ts
@@ -1,0 +1,27 @@
+import { IsUUID, IsEnum } from 'class-validator';
+import { Role } from '@prisma/client';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class AssignUserToShopDto {
+  @ApiProperty({
+    example: 'user-uuid-here',
+    description: 'UUID of the user to assign',
+  })
+  @IsUUID()
+  userId: string;
+
+  @ApiProperty({
+    example: 'shop-uuid-here',
+    description: 'UUID of the shop to assign the user to',
+  })
+  @IsUUID()
+  shopId: string;
+
+  @ApiProperty({
+    enum: Role,
+    example: Role.USER,
+    description: 'Role of the user in the shop',
+  })
+  @IsEnum(Role)
+  role: Role;
+}

--- a/backend/src/shop/dto/shop-user-response.dto.ts
+++ b/backend/src/shop/dto/shop-user-response.dto.ts
@@ -1,0 +1,41 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Role } from '@prisma/client';
+
+class UserDto {
+  @ApiProperty({ example: 'user_abc123' })
+  id: string;
+
+  @ApiProperty({ example: 'johndoe@example.com' })
+  email: string;
+
+  @ApiProperty({ example: 'John Doe' })
+  name: string;
+}
+
+class ShopDto {
+  @ApiProperty({ example: 'shop_xyz789' })
+  id: string;
+
+  @ApiProperty({ example: 'Vaultly Card Shop' })
+  name: string;
+
+  @ApiProperty({ example: '123 Card St, Las Vegas, NV' })
+  address: string;
+}
+
+export class ShopUserResponseDto {
+  @ApiProperty({ example: 'shusr_123456' })
+  id: string;
+
+  @ApiProperty({ enum: Role, example: Role.USER })
+  role: Role;
+
+  @ApiProperty({ example: '2025-03-29T01:23:45.000Z' })
+  assignedAt: Date;
+
+  @ApiProperty({ type: UserDto })
+  user: UserDto;
+
+  @ApiProperty({ type: ShopDto })
+  shop: ShopDto;
+}

--- a/backend/src/shop/shop.controller.ts
+++ b/backend/src/shop/shop.controller.ts
@@ -13,12 +13,15 @@ import {
   import { CurrentUser } from 'src/common/decorators/current-user.decorator';
   import {
     ApiBearerAuth,
+    ApiBody,
     ApiOkResponse,
     ApiOperation,
     ApiResponse,
     ApiTags,
   } from '@nestjs/swagger';
 import { CreateShopDto } from './dto/create-shop.dto';
+import { AssignUserToShopDto } from './dto/assign-user-to-shop.dto';
+import { ShopUserResponseDto } from './dto/shop-user-response.dto';
   
   @ApiTags('shop')
   @Controller('shop')
@@ -55,5 +58,20 @@ import { CreateShopDto } from './dto/create-shop.dto';
     ) {
       return this.shopService.updateShop(user.id, shopId, dto);
     }
+
+    @Post('assign-user')
+    @UseGuards(AuthGuard('jwt'))
+    @ApiBearerAuth('access-token')
+    @ApiOperation({ summary: 'Admin assigns user to a shop' })
+    @ApiBody({ type: AssignUserToShopDto })
+    @ApiOkResponse({ description: 'User assigned successfully', type: ShopUserResponseDto })
+    @ApiResponse({ status: 403, description: 'Forbidden' })
+    async assignUserToShop(
+      @CurrentUser() user: any,
+      @Body() dto: AssignUserToShopDto,
+    ): Promise<ShopUserResponseDto> {
+      return this.shopService.assignUserToShop(user.id, dto);
+    }
+
   }
   

--- a/backend/src/shop/shop.service.ts
+++ b/backend/src/shop/shop.service.ts
@@ -1,76 +1,135 @@
 import {
-    ForbiddenException,
-    Injectable,
-    NotFoundException,
-  } from '@nestjs/common';
-  import { UpdateShopDto } from './dto/update-shop.dto';
-  import { CreateShopDto } from './dto/create-shop.dto';
-  import { PrismaService } from 'src/prisma/prisma.service';
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { UpdateShopDto } from './dto/update-shop.dto';
+import { CreateShopDto } from './dto/create-shop.dto';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { AssignUserToShopDto } from './dto/assign-user-to-shop.dto';
+import { Role } from '@prisma/client';
+
+@Injectable()
+export class ShopService {
+  constructor(private prisma: PrismaService) {}
+
+  async createShop(userId: string, dto: CreateShopDto) {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { role: true },
+    });
+
+    if (!user || user.role !== 'ADMIN') {
+      throw new ForbiddenException('Only admins can create shops.');
+    }
+
+    const shop = await this.prisma.shop.create({
+      data: {
+        ...dto,
+      },
+    });
+
+    // Assign creator to shop via ShopUser
+    await this.prisma.shopUser.create({
+      data: {
+        userId,
+        shopId: shop.id,
+        role: Role.ADMIN,
+      },
+    });
+
+    return shop;
+  }
+
+  async updateShop(userId: string, shopId: string, dto: UpdateShopDto) {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      include: {
+        shopUsers: {
+          where: { shopId },
+          select: { role: true },
+        },
+      },
+    });
+
+    if (!user || user.role !== 'ADMIN') {
+      throw new ForbiddenException('Only admins can update shops.');
+    }
+
+    const shop = await this.prisma.shop.findUnique({
+      where: { id: shopId },
+    });
+
+    if (!shop) {
+      throw new NotFoundException('Shop not found.');
+    }
+
+    const isAssignedToShop = user.shopUsers.length > 0;
+    if (!isAssignedToShop) {
+      throw new ForbiddenException('You do not have access to edit this shop.');
+    }
+
+    return this.prisma.shop.update({
+      where: { id: shopId },
+      data: {
+        ...dto,
+        updatedAt: new Date(),
+      },
+    });
+  }
+
+  async assignUserToShop(adminId: string, dto: AssignUserToShopDto) {
+    const admin = await this.prisma.user.findUnique({
+      where: { id: adminId },
+    });
   
-  @Injectable()
-  export class ShopService {
-    constructor(private prisma: PrismaService) {}
+    if (!admin || admin.role !== 'ADMIN') {
+      throw new ForbiddenException('Only admins can assign users to shops.');
+    }
   
-    async createShop(userId: string, dto: CreateShopDto) {
-      const user = await this.prisma.user.findUnique({
-        where: { id: userId },
-        select: { role: true },
-      });
+    const { userId, shopId, role } = dto;
   
-      if (!user || user.role !== 'ADMIN') {
-        throw new ForbiddenException('Only admins can create shops.');
-      }
+    const [user, shop] = await Promise.all([
+      this.prisma.user.findUnique({ where: { id: userId } }),
+      this.prisma.shop.findUnique({ where: { id: shopId } }),
+    ]);
   
-      const shop = await this.prisma.shop.create({
-        data: {
-          ...dto,
-          users: {
-            connect: { id: userId }, // Link user to shop
+    if (!user) throw new NotFoundException('User not found.');
+    if (!shop) throw new NotFoundException('Shop not found.');
+  
+    const existing = await this.prisma.shopUser.findFirst({
+      where: { userId, shopId },
+    });
+  
+    if (existing) {
+      throw new ForbiddenException('User is already assigned to this shop.');
+    }
+  
+    const shopUser = await this.prisma.shopUser.create({
+      data: {
+        userId,
+        shopId,
+        role,
+      },
+      include: {
+        user: {
+          select: {
+            id: true,
+            email: true,
+            name: true,
           },
         },
-      });
-  
-      // Set user's shop_id (1-to-1 reference)
-      await this.prisma.user.update({
-        where: { id: userId },
-        data: {
-          shop_id: shop.id,
+        shop: {
+          select: {
+            id: true,
+            name: true,
+            address: true,
+          },
         },
-      });
+      },
+    });
   
-      return shop;
-    }
-  
-    async updateShop(userId: string, shopId: string, dto: UpdateShopDto) {
-      const user = await this.prisma.user.findUnique({
-        where: { id: userId },
-        select: { role: true, shop_id: true },
-      });
-  
-      if (!user || user.role !== 'ADMIN') {
-        throw new ForbiddenException('Only admins can update shops.');
-      }
-  
-      const shop = await this.prisma.shop.findUnique({
-        where: { id: shopId },
-      });
-  
-      if (!shop) {
-        throw new NotFoundException('Shop not found.');
-      }
-  
-      // Optional security: restrict editing to assigned shop
-      if (user.shop_id !== shopId) {
-        throw new ForbiddenException('You do not have access to edit this shop.');
-      }
-  
-      return this.prisma.shop.update({
-        where: { id: shopId },
-        data: {
-          ...dto,
-          updatedAt: new Date(),
-        },
-      });
-    }
+    return shopUser;
   }
   
+}


### PR DESCRIPTION
This PR introduces the ability for platform-wide admins to assign a user to a specific shop with a scoped role (USER, ADMIN, etc.) via the ShopUser table.

Endpoints added:
- `POST /shop/assign-user`
   - Assigns a user to a shop if the current user is a platform admin
   - Prevents duplicate assigments
   - Swagger docs include body + response example