### PR TITLE
VAUL-64: handle user deletion and cascade shop soft/hard delete logic

### DIFF
--- a/backend/prisma/migrations/20250329101253_add_shop_role_enum/migration.sql
+++ b/backend/prisma/migrations/20250329101253_add_shop_role_enum/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - The `role` column on the `ShopUser` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+
+*/
+-- CreateEnum
+CREATE TYPE "ShopRole" AS ENUM ('OWNER', 'MANAGER', 'SALES_REP');
+
+-- AlterTable
+ALTER TABLE "ShopUser" DROP COLUMN "role",
+ADD COLUMN     "role" "ShopRole" NOT NULL DEFAULT 'SALES_REP';

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1,9 +1,3 @@
-// This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
-
-// Looking for ways to speed up your queries, or scale easily with your serverless or edge functions?
-// Try Prisma Accelerate: https://pris.ly/cli/accelerate-init
-
 generator client {
   provider = "prisma-client-js"
 }
@@ -13,22 +7,28 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-model User {
-  id        String      @id @default(uuid())
-  name      String
-  email     String      @unique
-  password  String
-  role      Role        @default(USER)
-  createdAt DateTime    @default(now())
-  updatedAt DateTime    @default(now())
-  deletedAt DateTime?
-
-  shopUsers ShopUser[]
-}
-
 enum Role {
   USER
   ADMIN
+}
+
+enum ShopRole {
+  OWNER
+  MANAGER
+  SALES_REP
+}
+
+model User {
+  id         String      @id @default(uuid())
+  name       String
+  email      String      @unique
+  password   String
+  role       Role        @default(USER)
+  createdAt  DateTime    @default(now())
+  updatedAt  DateTime    @default(now())
+  deletedAt  DateTime?
+
+  shopUsers  ShopUser[]
 }
 
 model Shop {
@@ -45,17 +45,18 @@ model Shop {
   updatedAt  DateTime    @default(now())
   deletedAt  DateTime?
 
-  shopUsers ShopUser[]
+  shopUsers  ShopUser[]
 }
 
 model ShopUser {
-  id        String   @id @default(uuid())
-  user      User     @relation(fields: [userId], references: [id])
-  userId    String
-  shop      Shop     @relation(fields: [shopId], references: [id])
-  shopId    String   @default(uuid())
-  role      Role     @default(USER)
+  id         String   @id @default(uuid())
+  user       User     @relation(fields: [userId], references: [id])
+  userId     String
+  shop       Shop     @relation(fields: [shopId], references: [id])
+  shopId     String
+  role       ShopRole @default(SALES_REP)
   assignedAt DateTime @default(now())
 
   @@unique([userId, shopId])
 }
+

--- a/backend/src/auth/dtos/user-profile-response.dto.ts
+++ b/backend/src/auth/dtos/user-profile-response.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { Role } from '@prisma/client';
+import { Role, ShopRole } from '@prisma/client';
 
 class ShopProfileDto {
   @ApiProperty()
@@ -30,36 +30,30 @@ class ShopProfileDto {
   planId?: string | null;
 }
 
-class ShopAssignmentDto {
-  @ApiProperty({ enum: Role })
-  role: Role;
+export class ShopAssignmentDto {
+  @ApiProperty({ example: 'shop_123456' })
+  shopId: string;
 
-  @ApiProperty()
-  assignedAt: Date;
+  @ApiProperty({ example: 'Vaultly Card Shop' })
+  shopName: string;
 
-  @ApiProperty({ type: ShopProfileDto })
-  shop: ShopProfileDto;
+  @ApiProperty({ enum: ShopRole, example: ShopRole.SALES_REP })
+  role: ShopRole;
 }
 
 export class UserProfileResponseDto {
-  @ApiProperty()
+  @ApiProperty({ example: 'user_abc123' })
   id: string;
 
-  @ApiProperty()
+  @ApiProperty({ example: 'johndoe@example.com' })
   email: string;
 
-  @ApiProperty()
+  @ApiProperty({ example: 'John Doe' })
   name: string;
 
-  @ApiProperty({ enum: Role })
+  @ApiProperty({ enum: Role, example: Role.USER })
   role: Role;
 
-  @ApiProperty()
-  createdAt: Date;
-
-  @ApiProperty()
-  updatedAt: Date;
-
-  @ApiProperty({ type: [ShopAssignmentDto], required: false })
+  @ApiProperty({ type: [ShopAssignmentDto] })
   shopUsers: ShopAssignmentDto[];
 }

--- a/backend/src/shop/dto/assign-user-to-shop.dto.ts
+++ b/backend/src/shop/dto/assign-user-to-shop.dto.ts
@@ -1,5 +1,5 @@
 import { IsUUID, IsEnum } from 'class-validator';
-import { Role } from '@prisma/client';
+import { ShopRole } from '@prisma/client';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class AssignUserToShopDto {
@@ -18,10 +18,10 @@ export class AssignUserToShopDto {
   shopId: string;
 
   @ApiProperty({
-    enum: Role,
-    example: Role.USER,
-    description: 'Role of the user in the shop',
+    enum: ShopRole,
+    example: ShopRole.SALES_REP,
+    description: 'Shop-level role to assign',
   })
-  @IsEnum(Role)
-  role: Role;
+  @IsEnum(ShopRole)
+  role: ShopRole;
 }

--- a/backend/src/shop/dto/shop-user-response.dto.ts
+++ b/backend/src/shop/dto/shop-user-response.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { Role } from '@prisma/client';
+import { ShopRole } from '@prisma/client';
 
 class UserDto {
   @ApiProperty({ example: 'user_abc123' })
@@ -27,8 +27,8 @@ export class ShopUserResponseDto {
   @ApiProperty({ example: 'shusr_123456' })
   id: string;
 
-  @ApiProperty({ enum: Role, example: Role.USER })
-  role: Role;
+  @ApiProperty({ enum: ShopRole, example: ShopRole.SALES_REP })
+  role: ShopRole;
 
   @ApiProperty({ example: '2025-03-29T01:23:45.000Z' })
   assignedAt: Date;

--- a/backend/src/shop/shop.service.ts
+++ b/backend/src/shop/shop.service.ts
@@ -7,7 +7,7 @@ import { UpdateShopDto } from './dto/update-shop.dto';
 import { CreateShopDto } from './dto/create-shop.dto';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { AssignUserToShopDto } from './dto/assign-user-to-shop.dto';
-import { Role } from '@prisma/client';
+import { Role, ShopRole } from '@prisma/client';
 
 @Injectable()
 export class ShopService {
@@ -34,7 +34,7 @@ export class ShopService {
       data: {
         userId,
         shopId: shop.id,
-        role: Role.ADMIN,
+        role: ShopRole.OWNER,
       },
     });
 


### PR DESCRIPTION
This PR implements the logic for handling user deletions in relation to shops they own:

Soft Delete Flow
- When a user soft-deletes their account:
   - Their `deletedAt` timestamp is set.
   - All shops they own (via `ShopUser.role === OWNER`) are also soft-deleted.
   - This allows a grace period before permanent deletion.

Cancel Deletion
- If a soft-deleted user cancels their deletion request:
   - Their `deletedAt` is cleared.
   - All their owned shops are also restored.

Hard Delete Flow
- When a user is permanently deleted (via hardDeleteUser() method):
   - All ShopUser assignments related to their owned shops are removed.
   - All owned shops are fully deleted.
   - Their user account and shop-user records are deleted from the database.

Additional Changes
- Introduced a new enum: ShopRole (OWNER, MANAGER, SALES_REP)
- Updated schema and services to support scoped shop roles (separate from global Role)
- Updated AuthService, ShopService, and DTOs to align with the new schema